### PR TITLE
correct dates workshop

### DIFF
--- a/content/schedule.yaml
+++ b/content/schedule.yaml
@@ -2,37 +2,29 @@
 # all times must be input in UTC, be careful about daylight saving
 schedule:
   - title: "Installation help and on-boarding"
-    date: "2024-03-05"
+    date: "2024-09-04"
     sessions:
-      - starts: 9:30
-        ends: 10:30
+      - starts: 9:00
+        ends: 10:00
         title: On-boarding for team leaders (option 1)
         url: https://coderefinery.github.io/manuals/team-leaders/
-      - starts: 11:00
-        ends: 12:00
-        title: On-boarding for team leaders (option 2)
-        url: https://coderefinery.github.io/manuals/team-leaders/
-      - starts: 12:30
-        ends: 14:00
+      - starts: 10:00
+        ends: 11:00
         title: Installation help for everybody (option 1)
         url: https://coderefinery.github.io/installation/
   - title: "Installation help and on-boarding (you don't need to attend all sessions, choose the one that is better for you)"
-    date: "2024-03-07"
+    date: "2024-09-05"
     sessions:
-      - starts: 9:30
-        ends: 10:30
-        title: On-boarding for team leaders (option 3)
+      - starts: 9:00
+        ends: 10:00
+        title: On-boarding for team leaders (option 2)
         url: https://coderefinery.github.io/manuals/team-leaders/
-      - starts: 11:00
-        ends: 12:00
-        title: On-boarding for team leaders (option 4)
-        url: https://coderefinery.github.io/manuals/team-leaders/
-      - starts: 12:30
-        ends: 14:00
+      - starts: 10:00
+        ends: 11:00
         title: Installation help for everybody (option 2)
         url: https://coderefinery.github.io/installation/
   - title: "Day 1"
-    date: "2024-03-12"
+    date: "2024-09-10"
     sessions:
       - starts: 8:00
         ends: 8:20
@@ -52,7 +44,7 @@ schedule:
         presenters: TBA
         subtitle: "[Merging](https://coderefinery.github.io/git-intro/merging/)"
   - title: "Day 2"
-    date: "2024-03-13"
+    date: "2024-09-11"
     sessions:
       - starts: 8:00
         ends: 10:00
@@ -67,7 +59,7 @@ schedule:
         presenters: TBA
         subtitle: "[Sharing work](https://coderefinery.github.io/git-intro/sharing/)"
   - title: "Day 3"
-    date: "2024-03-14"
+    date: "2024-09-12"
     sessions:
       - starts: 8:00
         ends: 10:00
@@ -91,7 +83,7 @@ schedule:
           [Contributing to others](https://coderefinery.github.io/git-collaborative/forking-workflow/)
 
   - title: "Day 4"
-    date: "2024-03-19"
+    date: "2024-09-17"
     sessions:
       - starts: 8:00
         ends: 10:00
@@ -106,7 +98,7 @@ schedule:
         url: https://coderefinery.github.io/social-coding/
         presenters: TBA
   - title: "Day 5"
-    date: "2024-03-20"
+    date: "2024-09-18"
     sessions:
       - starts: 8:00
         ends: 10:00
@@ -120,7 +112,7 @@ schedule:
         url: https://coderefinery.github.io/jupyter/
         presenters: TBA
   - title: "Day 6"
-    date: "2024-03-21"
+    date: "2024-09-19"
     sessions:
       - starts: 8:00
         ends: 10:00
@@ -140,13 +132,13 @@ schedule:
         url: https://github.com/coderefinery/workshop-outro/blob/master/README.md
         presenters: TBA
   - title: "Optional: Bring your own code session"
-    date: "2024-03-26"
+    date: "2024-10-22"
     sessions:
       - starts: 12:00
         ends: 14:00
         title: Bring your own code and discuss and ask; you can also join this session if you have not attended the workshop
   - title: "Optional: Bring your own code session"
-    date: "2024-04-02"
+    date: "2024-10-29"
     sessions:
       - starts: 11:00
         ends: 13:00


### PR DESCRIPTION
Corrected the dates for the workshop. Thx to @samumantha for pointing it out.
Decreased the number of onboarding sessions.
Bring your own code preliminary set to Oct 22 and 29. @bast, I hope you can be there for these sessions as well. I would appreciate it you chose dates that work for you.